### PR TITLE
Modify docker container setup to use SuiteCRM files on the host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,5 @@
 # These environment variables are used to configure the docker container.
-# The passwords (DB_CRM_PASS, DB_CRM_ROOT_PASSWORD, CRM_PASS)
-# should be changed for any servers open to the world.
 
-# CRM store database
-DB_CRM_ROOT_PASSWORD = "rootpass"
-DB_CRM_PASS = "pass"
-DB_CRM_HEALTHCHECK_INTERVAL = "10s"
-DB_CRM_HEALTHCHECK_TIMEOUT = "60s"
-DB_CRM_HEALTHCKECK_RETRIES = "5"
-DB_CRM_LOCAL_PATH = "./data/crm-store-mariadb"
-DB_CRM_PORT = 3306
-DB_CRM_NAME = "suitecrm"
-DB_CRM_USER = "suitecrm"
-
-# CRM
-CRM_USER = "admin"
-CRM_PASS = "password"
-CRM_PUBLIC_SSL_PORT = 8443
-CRM_PUBLIC_PORT = 8080
-CRM_LOCAL_PATH = "./data/crm-local-data"
+IATI_CRM_LOCALDEV_USERID = 9999
+IATI_CRM_LOCALDEV_GROUPID = 9999
+IATI_CRM_PATH = ~/iati-suitecrm/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Local storage for registry and local setup
 data/
 .env
+suitecrm/private.key
+suitecrm/public.key
 
 # Python environments
 .ve/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM docker.io/bitnami/suitecrm:7.14.6-debian-12-r2
-
-RUN openssl genrsa -out /opt/bitnami/suitecrm/Api/V8/OAuth2/private.key 2048
-RUN openssl rsa -in /opt/bitnami/suitecrm/Api/V8/OAuth2/private.key -pubout -out /opt/bitnami/suitecrm/Api/V8/OAuth2/public.key
-RUN chmod 600 /opt/bitnami/suitecrm/Api/V8/OAuth2/private.key /opt/bitnami/suitecrm/Api/V8/OAuth2/public.key
-RUN chown daemon:daemon /opt/bitnami/suitecrm/Api/V8/OAuth2/p*.key

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 --- | ---
 Description | The (new) IATI Registry is a CIAM system using a CRM ([SuiteCRM](https://github.com/salesagility/SuiteCRM)) to store IATI organisation and dataset information, and an identity service ([WSO2](https://github.com/wso2/product-is)).  This repository contains various files to spin up a local development instance of the (new) IATI Registry and to generate fake data to put into the Registry for development and testing.  Currently this just contains the CRM component. 
 Website | None 
-Related | To test the registry you will need to install the [IATI Registry SuiteCRM Extension](https://github.com/IATI/iati-registry-suitecrm-extension).<br />To interact with the SuiteCRM API using Python there is a Python library: [IATI SuiteCRM Python Library](https://github.com/IATI/iati-registry-libsuitecrm). 
+Related | You will need a local copy of the SuiteCRM PHP files to run this development environment.<br />To interact with the SuiteCRM API using Python there is a Python library: [IATI SuiteCRM Python Library](https://github.com/IATI/iati-registry-libsuitecrm). 
 Documentation | Rest of README.md
 Technical Issues | [GitHub issues page](https://github.com/IATI/iati-registry-suitecrm-extension/issues) 
 Support | [IATI Support Website](https://iatistandard.org/en/guidance/get-support/) 
@@ -15,31 +15,96 @@ Support | [IATI Support Website](https://iatistandard.org/en/guidance/get-suppor
 
 * Docker.
 * Docker Compose.
+* openssl (or similar) to build public/private key pairs to use OAuth functionality.
 * Python (for running the faking tooling)
+* Linux (or other Unix-like) environment.
 
 ## Overview
 
+This development environment is setup to allow local development of SuiteCRM and authoring of changes to SuiteCRM that can then be committed into version control.  The system is setup so that the SuiteCRM distribution is held on the host machine, to allow local editing, committing, linting and so on, but that SuiteCRM is run in a container.  Some manual setup is required the first time the container is run.
+
 The `docker-compose.yaml` configures a CRM service and the database service that the CRM needs:
 
-1. `iati-dev-registry-crm`: [SuiteCRM](https://suitecrm.com/) is the IATI CRM.
-2. `iati-dev-registry-crm-db`: [MariaDB](https://mariadb.org/) is the store for the IATI CRM.
+1. `iati-dev-crm`: [SuiteCRM](https://suitecrm.com/) is the IATI CRM.
+2. `iati-dev-crm-db`: [MariaDB](https://mariadb.org/) is the store for the IATI CRM.
 
-At the moment the persistent data storage has been redirected to a local folder rather than use a Docker volume (see environment variables: `DB_CRM_LOCAL_PATH`, `CRM_LOCAL_PATH`).  This is to make it easier to inspect the file system during development.  It's envisaged that they would be rolled back into Docker volumes at some later stage.
+The DB is not setup through environment variables as the setup must match the SuiteCRM configuration file in `suitecrm/config_si.php`
 
 To fill the registry with mocked data, the there is a tool called `fakeiati.py` to generate a corpus of fake IATI data.  These are generated as CSV files that can be imported into SuiteCRM (with a few caveats).
 
 ## Getting started
 
-### Starting the Registry
+### Starting development of the SuiteCRM customisations
 
-From the command line issue:
+You must have a local copy of SuiteCRM, either cloned from the [SuiteCRM repository on GitHub](https://github.com/SuiteCRM/SuiteCRM), downloaded from the [SuiteCRM website](https://suitecrm.com/download/), or from the [IATI private repository](https://github.com/iati/iati-suitecrm).  For the purposes of these docs, it is assumed they are downloaded into `~/iati-suitecrm`.
+
+Copy the example `.env` file: `cp .env.example .env`.
+
+#### User and Group ID
+
+The first thing is to find your user and group id (e.g., using `id`) and set the variables `IATI_CRM_LOCALDEV_USERID` and `IATI_CRM_LOCALDEV_GROUPID` in `.env` to match.  This is so that the PHP environment in the container can properly access the SuiteCRM files on the host whilst remaining editable on the host.
+
+#### Path to the SuiteCRM files
+
+Set the `IATI_CRM_PATH` variable in `.env` to the path to the SuiteCRM files, e.g., `IATI_CRM_PATH = ~/iati-suitecrm/`.
+
+#### Set passwords
+
+If necessary, change the DB passwords in `docker-compose.yaml` and `suitecrm/config_si.php`.
+
+#### Public/private keys
+
+A public/private key pair is required if you want to interact with SuiteCRM using OAuth.  If so, execute the following in the root of this repository:
 
 ```
-cp .env.example .env
-docker compose up
+openssl genrsa -out suitecrm/private.key 2048
+openssl rsa -in suitecrm/private.key -pubout -out suitecrm/public.key
+chmod 600 suitecrm/private.key suitecrm/public.key
 ```
 
-Then you will need to fetch the [IATI Registry extension for SuiteCRM](https://github.com/IATI/iati-registry-suitecrm-extension) and install the zip file via the *Module Loader* section in the *Admin* section.  If you are opening your instance to the outside world it is recommended to change the default passwords in `.env`.
+#### Start the container and install requirements
+
+Now start the docker container (I normally force docker to rebuild the image the first time).  This may take some time if it's the first time as the container needs to build a number of PHP extensions.
+
+```
+docker compose up --build
+```
+
+As soon as the container is up, the second command installs all the dependencies using Composer.
+
+```
+docker exec iati-dev-crm composer install
+```
+
+Alternatively, `composer install` could be run after logging into the container with `docker exec -it iati-dev-crm bash`.
+
+#### SuiteCRM Install
+
+The final step is for SuiteCRM to install itself (setup local configuration files, build the database tables and so on).  The `suitecrm/config_si.php` file contains the configuration information to allow SuiteCRM to do this (see also [documentation on the SugarCRM website](https://support.sugarcrm.com/documentation/sugar_developer/sugar_developer_guide_13.0/architecture/configurator/silent_installer_settings/) and [a blog post](https://www.jsmackin.co.uk/suitecrm/suitecrm-command-line-install/)).  The installer can be run from the browser by opening `http://localhost:8080/install.php` or from the command line:
+
+```
+docker exec iati-dev-crm curl localhost:80/install.php?goto=SilentInstall&cli=true
+```
+
+You will see some warnings but they should not stop the installation from completing with:
+
+```
+<!--
+<bottle>Success!</bottle>
+-->
+```
+
+After this SuiteCRM is installed and you can log in by opening `http://localhost:8080` using the admin username and password as configured in `suitecrm/config_si.php`.
+
+### Linting of the SuiteCRM code
+
+As you are carrying out local development on the SuiteCRM files, you can lint the code using:
+
+```
+docker run -v ~/iati-suitecrm:/code ghcr.io/php-cs-fixer/php-cs-fixer:3-php8.3 fix
+```
+
+The file `.php-cs-fixer.dist.php` in the SuiteCRM root contains the configuration for this linter.
 
 ### Generating fake data
 
@@ -69,16 +134,7 @@ options:
 
 The `--safe-emails` and `--safe-urls` options will only generate from domains such as `example.org` to avoid the risk of traffic being sent to real URLs or email addresses in testing, and `--fake-uuids` will generate UUIDs with the first 8 characters set to a string so we can easily detect if UUIDs generated in the faker are discarded on import to external tools such as SuiteCRM.
 
-### Configuration
-
-The services are configured using environment variables in `.env` and an example is provided `.env.example`.  If this service is
-to be open to the outside world it is recommended to change the passwords.  The passwords that need to be set are:
-
-* `DB_CRM_PASS`: password to access the CRM database.
-* `DB_CRM_ROOT_PASSWORD`: root password for the CRM database.
-* `CRM_PASS`: password for the admin account of the CRM.
-
-### Development
+### Faker Development
 
 #### Checking and linting
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,40 +2,43 @@ name: iati-dev-registry
 
 services:
   crmdb:
-    container_name: iati-dev-registry-crm-db
+    container_name: iati-dev-crm-db
     image: mariadb:latest
     ports:
-      - ${DB_CRM_PORT}:${DB_CRM_PORT}
+      - 3306:3306
     environment:
-      MARIADB_ROOT_PASSWORD: ${DB_CRM_ROOT_PASSWORD}
-      MARIADB_DATABASE: "suitecrm"
-      MARIADB_USER: ${DB_CRM_USER}
-      MARIADB_PASSWORD: ${DB_CRM_PASS}
+      MARIADB_ROOT_PASSWORD: aWWGhZeedjI20XWv
+      MARIADB_DATABASE: suitecrm
+      MARIADB_USER: suitecrm_admin
+      MARIADB_PASSWORD: saO7tXCBTsxDjcz1
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       start_period: 10s
-      interval: ${DB_CRM_HEALTHCHECK_INTERVAL}
-      timeout: ${DB_CRM_HEALTHCHECK_TIMEOUT}
-      retries: ${DB_CRM_HEALTHCKECK_RETRIES}
+      interval: 2s
+      timeout: 60s
+      retries: 10
     volumes:
-      - "${DB_CRM_LOCAL_PATH}:/var/lib/mysql/"
+      - crm_db_data:/var/lib/mysql/"
 
   crm:
-    container_name: iati-dev-registry-crm
-    build: ./
+    container_name: iati-dev-crm
+    build:
+      context: ./suitecrm/
+      args:
+        USERID: ${IATI_CRM_LOCALDEV_USERID}
+        GROUPID: ${IATI_CRM_LOCALDEV_GROUPID}
     ports:
-      - ${CRM_PUBLIC_PORT}:8080
-      - ${CRM_PUBLIC_SSL_PORT}:8443
-    environment:
-      SUITECRM_USERNAME: ${CRM_USER}
-      SUITECRM_PASSWORD: ${CRM_PASS}
-      SUITECRM_DATABASE_HOST: iati-dev-registry-crm-db
-      SUITECRM_DATABASE_PORT_NUMBER: ${DB_CRM_PORT}
-      SUITECRM_DATABASE_NAME: "suitecrm"
-      SUITECRM_DATABASE_USER: ${DB_CRM_USER}
-      SUITECRM_DATABASE_PASSWORD: ${DB_CRM_PASS}
+      - 8080:80
     volumes:
-      - "$CRM_LOCAL_PATH:/bitnami/suitecrm"
+      - ${IATI_CRM_PATH}:/var/www/html
+      - ./suitecrm/config_si.php:/var/www/html/config_si.php
+      - ./suitecrm/private.key:/var/www/html/Api/V8/OAuth2/private.key
+      - ./suitecrm/public.key:/var/www/html/Api/V8/OAuth2/public.key
     depends_on:
       crmdb:
         condition: service_healthy
+
+volumes:
+  crm_db_data:
+    driver: local
+

--- a/suitecrm/Dockerfile
+++ b/suitecrm/Dockerfile
@@ -1,0 +1,40 @@
+FROM php:8.1.33-apache-bullseye
+
+ARG USERID
+ARG GROUPID
+
+# Force the www-data user and group in the container
+# to match the external user and group IDs.
+RUN groupmod -g ${GROUPID} www-data
+RUN usermod -u ${USERID} www-data
+
+# Update and install required packages.
+RUN apt-get update -y && apt-get upgrade -y
+RUN apt-get install -y curl git wget nano \
+    openssl libfreetype-dev libjpeg62-turbo-dev libpng-dev libzip-dev zlib1g-dev libjpeg-dev
+
+# Add additional PHP extensions.
+RUN docker-php-ext-configure zip
+RUN docker-php-ext-install zip
+RUN docker-php-ext-enable zip
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg
+RUN docker-php-ext-install gd
+RUN docker-php-ext-enable gd
+RUN docker-php-ext-configure mysqli
+RUN docker-php-ext-install mysqli
+RUN docker-php-ext-enable mysqli
+
+# Install composer.
+RUN wget https://raw.githubusercontent.com/composer/getcomposer.org/f3108f64b4e1c1ce6eb462b159956461592b3e3e/web/installer -O - -q | php -- --install-dir=/usr/bin/ --filename-composer --quiet
+
+# Setup PHP configuration file.
+RUN cp "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+
+WORKDIR /usr/local/etc/php
+COPY php.ini.patch /usr/local/etc/php
+RUN patch -u php.ini -i php.ini.patch
+
+# Create upload folder.
+RUN mkdir /var/www/html/upload
+
+WORKDIR /var/www/html/

--- a/suitecrm/config_si.php
+++ b/suitecrm/config_si.php
@@ -1,0 +1,42 @@
+<?php
+
+$sugar_config_si = array(
+    /*
+    ** System setup.
+    */
+    'setup_system_name' => 'IATI CRM',
+    'setup_site_url' => 'localhost:8080',
+    'setup_site_admin_user_name' => 'admin',
+    'setup_site_admin_password' => 'password',
+    'setup_db_pop_demo_data' => false,
+
+    /*
+    ** Database settings.
+    */
+    'setup_db_type' => 'mysql',
+    'setup_db_host_name' => 'iati-dev-crm-db',
+    'setup_db_port_num' => 3306,
+    'setup_db_database_name' => 'suitecrm',
+    'setup_db_admin_user_name' => 'suitecrm_admin',
+    'setup_db_admin_password' => 'saO7tXCBTsxDjcz1',
+    'setup_db_create_database' => 1,
+    'setup_db_drop_tables' => 0,
+    'setup_db_username_is_privileged' => true,
+    'dbUSRData' => 'create',
+
+    /*
+    ** Default locale settings.
+    */
+    'export_delimiter' => ',',
+    'default_export_charset' => 'ISO-8859-1',
+    'default_currency_iso4217' => 'USD',
+    'default_currency_name' => 'US Dollar',
+    'default_currency_significant_digits' => '2',
+    'default_currency_symbol' => '$',
+    'default_language' => 'en_us',
+    'default_date_format' => 'Y-m-d',
+    'default_time_format' => 'H:i',
+    'default_decimal_seperator' => '.',
+    'default_number_grouping_seperator' => ',',
+    'default_locale_name_format' => 's f l',
+);

--- a/suitecrm/php.ini.patch
+++ b/suitecrm/php.ini.patch
@@ -1,0 +1,11 @@
+--- php.ini-development	2025-08-04 20:58:07.000000000 +0000
++++ php.ini	2025-08-11 13:58:07.213990563 +0000
+@@ -486,7 +486,7 @@
+ ; Development Value: E_ALL
+ ; Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
+ ; https://php.net/error-reporting
+-error_reporting = E_ALL
++error_reporting = E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED
+ 
+ ; This directive controls whether or not and where PHP will output errors,
+ ; notices and warnings too. Error output is very useful during development, but


### PR DESCRIPTION
This PR modifies the local development docker container setup to work with SuiteCRM files on the host.  This allows us to work with a SuiteCRM distribution, develop those files locally on the host, and commit them to version control.

The single commit in this PR includes:
- a new Dockerfile built from a PHP base which is configured to access SuiteCRM files from the host
- a configuration file for SuiteCRM to silently install itself
- a small patch to the PHP configuration to change logging.

The compose file is adjusted to remove a lot of configuration and to share the locally hosted files with the container.